### PR TITLE
Fix applyProperties method for invalid or readonly attributes in Safari

### DIFF
--- a/lib/patch/applyProperties.js
+++ b/lib/patch/applyProperties.js
@@ -16,7 +16,10 @@ function applyProperties(node, props, previous) {
       if (isObject(propValue)) {
         patchObject(node, props, previous, propName, propValue);
       } else {
-        node[propName] = propValue
+        try {
+          // this is a workaround in case of invalid value or readonly propName
+          node[propName] = propValue;
+        } catch(err) {}
       }
     }
   }


### PR DESCRIPTION
https://xohellobar.atlassian.net/browse/CE-65
